### PR TITLE
feat: improve locale support (resolves #10)

### DIFF
--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -167,6 +167,8 @@ class HearthCommand extends Command
         // Language files...
         (new Filesystem())->copyDirectory(__DIR__.'/../../stubs/resources/lang/', resource_path('lang'));
 
+        // Prompt for additional languages...
+        $this->maybeAddLocale();
 
         $this->line('');
         $this->info('Hearth scaffolding installed successfully.');

--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -2,6 +2,7 @@
 
 namespace Hearth\Commands;
 
+use CommerceGuys\Intl\Language\LanguageRepository;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
@@ -111,8 +112,10 @@ class HearthCommand extends Command
         ];
 
         foreach ($config_stubs as $config) {
-            copy(__DIR__ . "/../../stubs/config/{$config}", base_path("config/{$config}"));
+            copy(__DIR__ . "/../../stubs/config/{$config}", config_path($config));
         }
+
+        // Add languages
 
         // Route stubs...
         $route_stubs = [
@@ -168,6 +171,34 @@ class HearthCommand extends Command
         $this->line('');
         $this->info('Hearth scaffolding installed successfully.');
         $this->comment('Please execute "npm install && npm run dev" to build your assets.');
+    }
+
+    /**
+     * Add a new locale to config/locales.php based on user input.
+     *
+     * @param  string  $after
+     * @return void
+     */
+    protected function maybeAddLocale($after = 'en')
+    {
+        if ($this->confirm('Do you want to add support for an additional locale?', true)) {
+            $languages = (new LanguageRepository())->getList();
+
+            $language = $this->anticipate('Choose a language', $languages);
+
+            $language_code = array_search($language, $languages);
+
+            $this->replaceInFile(
+                "'{$after}',",
+                "'{$after}',
+        '{$language_code}',",
+                config_path('locales.php')
+            );
+
+            $this->info("{$language} added to locales!");
+
+            $this->maybeAddLocale($language_code);
+        }
     }
 
     /**

--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -116,6 +116,7 @@ class HearthCommand extends Command
         }
 
         // Add languages
+        $this->maybeAddLocale();
 
         // Route stubs...
         $route_stubs = [
@@ -166,9 +167,6 @@ class HearthCommand extends Command
 
         // Language files...
         (new Filesystem())->copyDirectory(__DIR__.'/../../stubs/resources/lang/', resource_path('lang'));
-
-        // Prompt for additional languages...
-        $this->maybeAddLocale();
 
         $this->line('');
         $this->info('Hearth scaffolding installed successfully.');

--- a/stubs/config/locales.php
+++ b/stubs/config/locales.php
@@ -12,6 +12,5 @@ return [
 
     'supported' => [
         'en',
-        'fr',
     ],
 ];

--- a/stubs/resources/lang/en/validation.php
+++ b/stubs/resources/lang/en/validation.php
@@ -135,9 +135,7 @@ return [
     */
 
     'custom' => [
-        'attribute-name' => [
-            'rule-name' => 'custom-message',
-        ],
+        'attribute-name' => [],
     ],
 
     /*

--- a/stubs/resources/views/auth/register.blade.php
+++ b/stubs/resources/views/auth/register.blade.php
@@ -12,7 +12,7 @@
         <form method="POST" action="{{ localized_route('register') }}">
             @csrf
 
-            <x-hearth-input id="locale" type="hidden" name="locale" value="{{ locale() ?: 'en' }}" />
+            <x-hearth-input id="locale" type="hidden" name="locale" value="{{ locale() ?: config('app.locale') }}" />
 
             <!-- Name -->
             <div class="field">


### PR DESCRIPTION
- [x] Interactive command line interface to allow a user to enable support for additional languages when installing Hearth
- [x] Ensure that all language configuration data is loaded from `config/locales.php`

### Testing

1. Install this branch as a composer dependency.
2. Run `php artisan hearth:install`.
3. Use interactive prompts to select as many additional locales as needed.
4. Verify that the `config/locales.php` file includes the newly-selected locales.
5. Verify that the new locales are able to be selected via the user settings page and appear in the language switcher.