### PR TITLE
fix: add blank entry when retrieving list of regions

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           cd tests/integration
           composer require fluid-project/hearth:dev-${{ env.hearth_version }} --no-interaction
-          php artisan hearth:install --two-factor
+          php artisan hearth:install --two-factor --organizations --no-interaction
           npm install
           npm run production
 

--- a/database/factories/OrganizationFactory.php
+++ b/database/factories/OrganizationFactory.php
@@ -26,7 +26,7 @@ class OrganizationFactory extends Factory
         return [
             'name' => $this->faker->company(),
             'locality' => $this->faker->city(),
-            'region' => array_keys($regions)[$this->faker->numberBetween(0, 12)]
+            'region' => array_keys($regions)[$this->faker->numberBetween(1, 13)]
         ];
     }
 }

--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -147,7 +147,9 @@ class HearthCommand extends Command
         }
 
         // Add languages
-        $this->maybeAddLocale();
+        if (! $this->option('no-interaction')) {
+            $this->maybeAddLocale();
+        }
 
         // Route stubs...
         $route_stubs = [

--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 
 class HearthCommand extends Command
 {
-    public $signature = 'hearth:install {--two-factor} {--organizations} {--no-interaction}';
+    public $signature = 'hearth:install {--two-factor} {--organizations}';
 
     public $description = 'Install Hearth.';
 
@@ -147,9 +147,7 @@ class HearthCommand extends Command
         }
 
         // Add languages
-        if (! $this->option('no-interaction')) {
-            $this->maybeAddLocale();
-        }
+        $this->maybeAddLocale();
 
         // Route stubs...
         $route_stubs = [

--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -147,7 +147,7 @@ class HearthCommand extends Command
         }
 
         // Add languages
-        if (!$this->option('no-interaction')) {
+        if (! $this->option('no-interaction')) {
             $this->maybeAddLocale();
         }
 

--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Str;
 
 class HearthCommand extends Command
 {
-    public $signature = 'hearth:install {--two-factor} {--organizations}';
+    public $signature = 'hearth:install {--two-factor} {--organizations} {--no-interaction}';
 
     public $description = 'Install Hearth.';
 
@@ -147,7 +147,9 @@ class HearthCommand extends Command
         }
 
         // Add languages
-        $this->maybeAddLocale();
+        if (!$this->option('no-interaction')) {
+            $this->maybeAddLocale();
+        }
 
         // Route stubs...
         $route_stubs = [

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -39,7 +39,7 @@ if (! function_exists('get_regions')) {
     {
         $subdivisionRepository = new SubdivisionRepository();
 
-        $regions = [];
+        $regions = ['' => ''];
 
         foreach ($subdivisionRepository->getAll($countries) as $region) {
             $regions[$region->getCode()] = ($locale === $region->getLocale()) ? $region->getLocalName() : $region->getName();

--- a/stubs/config/locales.php
+++ b/stubs/config/locales.php
@@ -12,5 +12,6 @@ return [
 
     'supported' => [
         'en',
+        'fr',
     ],
 ];

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -4,8 +4,6 @@ namespace Hearth\Tests;
 
 class HelpersTest extends TestCase
 {
-
-
     public function test_get_region_name_in_default_locale()
     {
         $result = get_region_name('NS', ['CA']);

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -4,6 +4,8 @@ namespace Hearth\Tests;
 
 class HelpersTest extends TestCase
 {
+
+
     public function test_get_region_name_in_default_locale()
     {
         $result = get_region_name('NS', ['CA']);
@@ -20,6 +22,13 @@ class HelpersTest extends TestCase
     {
         $result = get_region_name('NS', ['US']);
         $this->assertNull($result);
+    }
+
+    public function test_get_regions_starts_with_blank_entry()
+    {
+        $result = get_regions(['CA']);
+        $this->assertEquals(array_key_first($result), '');
+        $this->assertEquals($result[''], '');
     }
 
     public function test_get_regions_in_default_locale()


### PR DESCRIPTION
Currently the `get_regions()` helper function does not include a blank entry. This means that a `<select>` element populated using this helper function defaults to the first region rather than requiring a user to make an explicit choice. This PR adds a blank entry as the first item in the array.

### Testing

1. Using this branch, navigate to `/en/organizations/create`.
2. Verify that the first option in the "Province or territory" dropdown is a blank selection.