### PR TITLE
fix: add return types to improve static analysis

### DIFF
--- a/stubs/app/Models/User.php
+++ b/stubs/app/Models/User.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Fortify\TwoFactorAuthenticatable;
@@ -94,16 +96,22 @@ class User extends Authenticatable implements HasLocalePreference, MustVerifyEma
 
     /**
      * Get the user's memberships.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     *
      */
-    public function memberships()
+    public function memberships(): HasMany
     {
         return $this->hasMany(Membership::class);
     }
 
     /**
      * Get the consulting organizations that belong to this user.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\MorphToMany
+     *
      */
-    public function organizations()
+    public function organizations(): MorphToMany
     {
         return $this->morphedByMany(Organization::class, 'membership')
             ->using('\App\Models\Membership')

--- a/stubs/app/Policies/UserPolicy.php
+++ b/stubs/app/Policies/UserPolicy.php
@@ -14,9 +14,10 @@ class UserPolicy
      * Determine whether the user can view any models.
      *
      * @param  \App\Models\User  $user
-     * @return mixed
+     *
+     * @return void
      */
-    public function viewAny(User $user)
+    public function viewAny(User $user): void
     {
         //
     }
@@ -26,9 +27,10 @@ class UserPolicy
      *
      * @param  \App\Models\User  $user
      * @param  \App\Models\User  $model
-     * @return mixed
+     *
+     * @return void
      */
-    public function view(User $user, User $model)
+    public function view(User $user, User $model): void
     {
         //
     }
@@ -37,9 +39,10 @@ class UserPolicy
      * Determine whether the user can create models.
      *
      * @param  \App\Models\User  $user
-     * @return mixed
+     *
+     * @return void
      */
-    public function create(User $user)
+    public function create(User $user): void
     {
         //
     }
@@ -77,9 +80,10 @@ class UserPolicy
      *
      * @param  \App\Models\User  $user
      * @param  \App\Models\User  $model
-     * @return mixed
+     *
+     * @return void
      */
-    public function restore(User $user, User $model)
+    public function restore(User $user, User $model): void
     {
         //
     }
@@ -89,9 +93,10 @@ class UserPolicy
      *
      * @param  \App\Models\User  $user
      * @param  \App\Models\User  $model
-     * @return mixed
+     *
+     * @return void
      */
-    public function forceDelete(User $user, User $model)
+    public function forceDelete(User $user, User $model): void
     {
         //
     }

--- a/stubs/app/Providers/FortifyServiceProvider.php
+++ b/stubs/app/Providers/FortifyServiceProvider.php
@@ -81,8 +81,10 @@ class FortifyServiceProvider extends ServiceProvider
 
     /**
      * Register response bindings.
+     *
+     * @return void
      */
-    protected function registerResponseBindings()
+    protected function registerResponseBindings(): void
     {
         $this->app->singleton(
             FailedTwoFactorLoginResponseContract::class,


### PR DESCRIPTION
I'm using [Psalm](https://psalm.dev) and [PHPStan](https://phpstan.org) for static analysis on the Accessibility in Action platform source code. This PR adds explicit return types to some class methods to ensure that they pass static analysis checks.