### PR TITLE
fix: use proper field types

### DIFF
--- a/stubs/resources/views/organizations/create.blade.php
+++ b/stubs/resources/views/organizations/create.blade.php
@@ -14,11 +14,11 @@
         <x-hearth-input id="user_id" type="hidden" name="user_id" :value="Auth::user()->id" required />
         <div class="field">
             <x-hearth-label for="name" :value="__('organization.label_name')" />
-            <x-hearth-input id="name" type="name" name="name" required />
+            <x-hearth-input id="name" type="text" name="name" required />
             </div>
         <div class="field">
             <x-hearth-label for="locality" :value="__('forms.label_locality')" />
-            <x-hearth-input id="locality" type="locality" name="locality" required />
+            <x-hearth-input id="locality" type="text" name="locality" required />
         </div>
         <div class="field">
             <x-hearth-label for="region" :value="__('forms.label_region')" />

--- a/stubs/resources/views/organizations/edit.blade.php
+++ b/stubs/resources/views/organizations/edit.blade.php
@@ -15,11 +15,11 @@
 
         <div class="field">
             <x-hearth-label for="name" :value="__('organization.label_name')" />
-            <x-hearth-input id="name" type="name" name="name" :value="old('name', $organization->name)" required />
+            <x-hearth-input id="name" type="text" name="name" :value="old('name', $organization->name)" required />
             </div>
         <div class="field">
             <x-hearth-label for="locality" :value="__('forms.label_locality')" />
-            <x-hearth-input id="locality" type="locality" name="locality" :value="old('locality', $organization->locality)" required />
+            <x-hearth-input id="locality" type="text" name="locality" :value="old('locality', $organization->locality)" required />
         </div>
         <div class="field">
             <x-hearth-label for="region" :value="__('forms.label_region')" />

--- a/stubs/resources/views/users/edit.blade.php
+++ b/stubs/resources/views/users/edit.blade.php
@@ -13,7 +13,7 @@
         @method('PUT')
         <div class="field">
             <x-hearth-label for="name" :value="__('hearth::user.label_name')" />
-            <x-hearth-input id="name" type="name" name="name" :value="old('name', $user->name)" required />
+            <x-hearth-input id="name" type="text" name="name" :value="old('name', $user->name)" required />
             @error('name', 'updateProfileInformation')
             <x-validation-error>{{ $message }}</x-validation-error>
             @enderror


### PR DESCRIPTION
Some of the templates included invalid field types due to developer error on my part. This PR fixes the problem.