### PR TITLE
feat: use Hearth strings where possible

### DIFF
--- a/stubs/app/Http/Requests/Auth/LoginRequest.php
+++ b/stubs/app/Http/Requests/Auth/LoginRequest.php
@@ -49,7 +49,7 @@ class LoginRequest extends FormRequest
             RateLimiter::hit($this->throttleKey());
 
             throw ValidationException::withMessages([
-                'email' => __('auth.failed'),
+                'email' => __('hearth::auth.failed'),
             ]);
         }
 
@@ -74,7 +74,7 @@ class LoginRequest extends FormRequest
         $seconds = RateLimiter::availableIn($this->throttleKey());
 
         throw ValidationException::withMessages([
-            'email' => trans('auth.throttle', [
+            'email' => trans('hearth::auth.throttle', [
                 'seconds' => $seconds,
                 'minutes' => ceil($seconds / 60),
             ]),


### PR DESCRIPTION
This PR updates the `LoginRequest` class to use error strings from the Hearth package rather than those from the Hearth-based project. If a Hearth integrator wants to modify these strings, they can publish them to their project:

```bash
php artisan vendor:publish --tag=hearth-translations
```

This will copy all of Hearth's translation files into `resources/lang/vendor/hearth` where an integrator can modify them as desired.