### PR TITLE
feat: improve error handling for invitation flow (resolves #28)

### DIFF
--- a/stubs/app/Actions/AcceptInvitation.php
+++ b/stubs/app/Actions/AcceptInvitation.php
@@ -96,7 +96,7 @@ class AcceptInvitation
             if ($user->email !== $email) {
                 $validator->errors()->add(
                     'email',
-                    __('invitation.email_not_valid', ['email' => $email])
+                    __('invitation.email_not_valid', ['email' => $user->email])
                 );
             }
         };

--- a/stubs/resources/lang/en/invitation.php
+++ b/stubs/resources/lang/en/invitation.php
@@ -9,7 +9,7 @@ return [
     'create_invitation_succeeded' => 'Your invitation has been sent.',
     'invited_user_already_belongs_to_team' => 'This user already belongs to this team.',
     'cancel_invitation_succeeded' => 'The invitation has been cancelled.',
-    'email_not_valid' => 'You must be logged in as :email to accept this invitation.',
+    'email_not_valid' => 'You are logged in as :email, but this invitation belongs to a different user.',
     'accept_invitation_succeeded' => 'You have joined the :inviteable team.',
     'invitations_title' => 'Member invitations',
     'invitation_email' => 'Email',

--- a/stubs/resources/lang/fr/invitation.php
+++ b/stubs/resources/lang/fr/invitation.php
@@ -9,7 +9,7 @@ return [
     'create_invitation_succeeded' => 'Your invitation has been sent.',
     'invited_user_already_belongs_to_team' => 'This user already belongs to this team.',
     'cancel_invitation_succeeded' => 'The invitation has been cancelled.',
-    'email_not_valid' => 'You must be logged in as :email to accept this invitation.',
+    'email_not_valid' => 'You are logged in as :email, but this invitation belongs to a different user.',
     'accept_invitation_succeeded' => 'You have joined the :inviteable team.',
     'invitations_title' => 'Member invitations',
     'invitation_email' => 'Email',


### PR DESCRIPTION
This PR updates the message displayed when a user attempts to accept an invitation meant for another user as described in #28. Now, the message says:

> You are logged in as bob@test.com, but this invitation is for a different email address.

This is an improvement over the previous message which disclosed the invitee's email address.