### PR TITLE
fix: properly handle empty input when adding locales (resolves #74)

### DIFF
--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -5,6 +5,7 @@ namespace Hearth\Commands;
 use CommerceGuys\Intl\Language\LanguageRepository;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Str;
 
 class HearthCommand extends Command
@@ -15,141 +16,146 @@ class HearthCommand extends Command
 
     public function handle()
     {
-        // Publish vendor files...
-        $this->callSilent('vendor:publish', ['--tag' => 'hearth-config', '--force' => true]);
-        $this->callSilent('vendor:publish', ['--tag' => 'hearth-migrations', '--force' => true]);
-        $this->callSilent('vendor:publish', ['--provider' => 'Laravel\Fortify\FortifyServiceProvider']);
-        $this->callSilent('vendor:publish', [
-            '--provider' => 'ChinLeung\LaravelLocales\LaravelLocalesServiceProvider',
-            '--tag' => 'config',
-        ]);
-        $this->callSilent('vendor:publish', [
-            '--provider' => 'Spatie\GoogleFonts\GoogleFontsServiceProvider',
-            '--tag' => 'google-fonts-config',
-        ]);
+        if (! App::environment('testing')) {
+            // Publish vendor files...
+            $this->callSilent('vendor:publish', ['--tag' => 'hearth-config', '--force' => true]);
+            $this->callSilent('vendor:publish', ['--tag' => 'hearth-migrations', '--force' => true]);
+            $this->callSilent('vendor:publish', ['--provider' => 'Laravel\Fortify\FortifyServiceProvider']);
+            $this->callSilent('vendor:publish', [
+                '--provider' => 'ChinLeung\LaravelLocales\LaravelLocalesServiceProvider',
+                '--tag' => 'config',
+            ]);
+            $this->callSilent('vendor:publish', [
+                '--provider' => 'Spatie\GoogleFonts\GoogleFontsServiceProvider',
+                '--tag' => 'google-fonts-config',
+            ]);
 
-        // Install NPM packages...
-        $this->updateNodePackages(function ($packages) {
-            return [
-                '@fluid-project/looseleaf' => '^1.6',
-                'alpinejs' => '^3.0',
-                'luxon' => '^2.0',
-            ] + $packages;
-        }, false);
+            // Install NPM packages...
+            $this->updateNodePackages(function ($packages) {
+                return [
+                    '@fluid-project/looseleaf' => '^1.6',
+                    'alpinejs' => '^3.0',
+                    'luxon' => '^2.0',
+                ] + $packages;
+            }, false);
 
-        $this->updateNodePackages(function ($packages) {
-            return [
-                'resolve-url-loader' => '^4.0.0',
-                'sass' => '^1.35',
-                'sass-loader' => '^12.1',
-            ] + $packages;
-        });
+            $this->updateNodePackages(function ($packages) {
+                return [
+                    'resolve-url-loader' => '^4.0.0',
+                    'sass' => '^1.35',
+                    'sass-loader' => '^12.1',
+                ] + $packages;
+            });
 
-        // Name...
-        $this->replaceInFile('APP_NAME=Laravel', 'APP_NAME=Hearth', base_path('.env'));
-        $this->replaceInFile('APP_NAME=Laravel', 'APP_NAME=Hearth', base_path('.env.example'));
+            // Name...
+            $this->replaceInFile('APP_NAME=Laravel', 'APP_NAME=Hearth', base_path('.env'));
+            $this->replaceInFile('APP_NAME=Laravel', 'APP_NAME=Hearth', base_path('.env.example'));
 
-        // AuthenticateSession Middleware...
-        $this->replaceInFile(
-            '// \Illuminate\Session\Middleware\AuthenticateSession::class,',
-            "\Illuminate\Session\Middleware\AuthenticateSession::class,",
-            app_path('Http/Kernel.php')
-        );
-
-        // DetectRequestLocale Middleware...
-        $this->installMiddlewareAfter('VerifyCsrfToken::class', '\ChinLeung\MultilingualRoutes\DetectRequestLocale::class');
-
-        // RedirectToPreferredLocale Middleware...
-        if (! Str::contains(file_get_contents(app_path('Http/Kernel.php')), '\App\Http\Middleware\RedirectToPreferredLocale::class')) {
+            // AuthenticateSession Middleware...
             $this->replaceInFile(
-                "'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,",
-                "'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
-            'localize' => \App\Http\Middleware\RedirectToPreferredLocale::class,",
+                '// \Illuminate\Session\Middleware\AuthenticateSession::class,',
+                "\Illuminate\Session\Middleware\AuthenticateSession::class,",
                 app_path('Http/Kernel.php')
             );
-        }
 
-        // RequirePassword Middleware...
-        $this->replaceInFile(
-            '\Illuminate\Auth\Middleware\RequirePassword::class',
-            '\App\Http\Middleware\RequirePassword::class',
-            app_path('Http/Kernel.php')
-        );
+            // DetectRequestLocale Middleware...
+            $this->installMiddlewareAfter(
+                'VerifyCsrfToken::class',
+                '\ChinLeung\MultilingualRoutes\DetectRequestLocale::class'
+            );
 
-        // FortifyServiceProvider...
-        $this->installServiceProviderAfter('RouteServiceProvider', 'FortifyServiceProvider');
+            // RedirectToPreferredLocale Middleware...
+            if (! Str::contains(file_get_contents(app_path('Http/Kernel.php')), '\App\Http\Middleware\RedirectToPreferredLocale::class')) {
+                $this->replaceInFile(
+                    "'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,",
+                    "'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'localize' => \App\Http\Middleware\RedirectToPreferredLocale::class,",
+                    app_path('Http/Kernel.php')
+                );
+            }
 
-        // Ensure folders are in place...
-        (new Filesystem())->ensureDirectoryExists(app_path('Actions/Fortify'));
-        (new Filesystem())->ensureDirectoryExists(app_path('Http/Requests'));
-        (new Filesystem())->ensureDirectoryExists(app_path('Http/Requests/Auth'));
-        (new Filesystem())->ensureDirectoryExists(app_path('Http/Responses'));
-        (new Filesystem())->ensureDirectoryExists(app_path('Mail'));
-        (new Filesystem())->ensureDirectoryExists(app_path('Policies'));
-        (new Filesystem())->ensureDirectoryExists(app_path('Rules'));
-        (new Filesystem())->ensureDirectoryExists(app_path('View/Components'));
+            // RequirePassword Middleware...
+            $this->replaceInFile(
+                '\Illuminate\Auth\Middleware\RequirePassword::class',
+                '\App\Http\Middleware\RequirePassword::class',
+                app_path('Http/Kernel.php')
+            );
 
-        // App stubs...
-        $app_stubs = [
-            'Actions/AcceptInvitation.php',
-            'Actions/DestroyMembership.php',
-            'Actions/UpdateMembership.php',
-            'Actions/Fortify/CreateNewUser.php',
-            'Actions/Fortify/PasswordValidationRules.php',
-            'Actions/Fortify/RedirectIfTwoFactorAuthenticatable.php',
-            'Actions/Fortify/UpdateUserPassword.php',
-            'Actions/Fortify/UpdateUserProfileInformation.php',
-            'Http/Controllers/InvitationController.php',
-            'Http/Controllers/MembershipController.php',
-            'Http/Controllers/OrganizationController.php',
-            'Http/Controllers/ResourceController.php',
-            'Http/Controllers/UserController.php',
-            'Http/Controllers/VerifyEmailController.php',
-            'Http/Middleware/Authenticate.php',
-            'Http/Middleware/RedirectIfAuthenticated.php',
-            'Http/Middleware/RedirectToPreferredLocale.php',
-            'Http/Middleware/RequirePassword.php',
-            'Http/Requests/Auth/LoginRequest.php',
-            'Http/Requests/DestroyUserRequest.php',
-            'Http/Requests/CreateInvitationRequest.php',
-            'Http/Requests/CreateOrganizationRequest.php',
-            'Http/Requests/DestroyOrganizationRequest.php',
-            'Http/Requests/UpdateOrganizationRequest.php',
-            'Http/Requests/CreateResourceRequest.php',
-            'Http/Requests/DestroyResourceRequest.php',
-            'Http/Requests/UpdateResourceRequest.php',
-            'Http/Responses/FailedTwoFactorLoginResponse.php',
-            'Http/Responses/LoginResponse.php',
-            'Http/Responses/PasswordResetResponse.php',
-            'Http/Responses/RegisterResponse.php',
-            'Http/Responses/TwoFactorLoginResponse.php',
-            'Mail/Invitation.php',
-            'Models/User.php',
-            'Models/Organization.php',
-            'Models/Membership.php',
-            'Models/Resource.php',
-            'Models/Invitation.php',
-            'Policies/OrganizationPolicy.php',
-            'Policies/ResourcePolicy.php',
-            'Policies/UserPolicy.php',
-            'Providers/FortifyServiceProvider.php',
-            'Rules/NotLastAdmin.php',
-            'Rules/Password.php',
-        ];
+            // FortifyServiceProvider...
+            $this->installServiceProviderAfter('RouteServiceProvider', 'FortifyServiceProvider');
 
-        foreach ($app_stubs as $path) {
-            copy(__DIR__ . "/../../stubs/app/{$path}", app_path($path));
-        }
+            // Ensure folders are in place...
+            (new Filesystem())->ensureDirectoryExists(app_path('Actions/Fortify'));
+            (new Filesystem())->ensureDirectoryExists(app_path('Http/Requests'));
+            (new Filesystem())->ensureDirectoryExists(app_path('Http/Requests/Auth'));
+            (new Filesystem())->ensureDirectoryExists(app_path('Http/Responses'));
+            (new Filesystem())->ensureDirectoryExists(app_path('Mail'));
+            (new Filesystem())->ensureDirectoryExists(app_path('Policies'));
+            (new Filesystem())->ensureDirectoryExists(app_path('Rules'));
+            (new Filesystem())->ensureDirectoryExists(app_path('View/Components'));
 
-        // Config stubs...
-        $config_stubs = [
-            'fortify.php',
-            'laravel-multilingual-routes.php',
-            'locales.php',
-        ];
+            // App stubs...
+            $app_stubs = [
+                'Actions/AcceptInvitation.php',
+                'Actions/DestroyMembership.php',
+                'Actions/UpdateMembership.php',
+                'Actions/Fortify/CreateNewUser.php',
+                'Actions/Fortify/PasswordValidationRules.php',
+                'Actions/Fortify/RedirectIfTwoFactorAuthenticatable.php',
+                'Actions/Fortify/UpdateUserPassword.php',
+                'Actions/Fortify/UpdateUserProfileInformation.php',
+                'Http/Controllers/InvitationController.php',
+                'Http/Controllers/MembershipController.php',
+                'Http/Controllers/OrganizationController.php',
+                'Http/Controllers/ResourceController.php',
+                'Http/Controllers/UserController.php',
+                'Http/Controllers/VerifyEmailController.php',
+                'Http/Middleware/Authenticate.php',
+                'Http/Middleware/RedirectIfAuthenticated.php',
+                'Http/Middleware/RedirectToPreferredLocale.php',
+                'Http/Middleware/RequirePassword.php',
+                'Http/Requests/Auth/LoginRequest.php',
+                'Http/Requests/DestroyUserRequest.php',
+                'Http/Requests/CreateInvitationRequest.php',
+                'Http/Requests/CreateOrganizationRequest.php',
+                'Http/Requests/DestroyOrganizationRequest.php',
+                'Http/Requests/UpdateOrganizationRequest.php',
+                'Http/Requests/CreateResourceRequest.php',
+                'Http/Requests/DestroyResourceRequest.php',
+                'Http/Requests/UpdateResourceRequest.php',
+                'Http/Responses/FailedTwoFactorLoginResponse.php',
+                'Http/Responses/LoginResponse.php',
+                'Http/Responses/PasswordResetResponse.php',
+                'Http/Responses/RegisterResponse.php',
+                'Http/Responses/TwoFactorLoginResponse.php',
+                'Mail/Invitation.php',
+                'Models/User.php',
+                'Models/Organization.php',
+                'Models/Membership.php',
+                'Models/Resource.php',
+                'Models/Invitation.php',
+                'Policies/OrganizationPolicy.php',
+                'Policies/ResourcePolicy.php',
+                'Policies/UserPolicy.php',
+                'Providers/FortifyServiceProvider.php',
+                'Rules/NotLastAdmin.php',
+                'Rules/Password.php',
+            ];
 
-        foreach ($config_stubs as $config) {
-            copy(__DIR__ . "/../../stubs/config/{$config}", config_path($config));
+            foreach ($app_stubs as $path) {
+                copy(__DIR__ . "/../../stubs/app/{$path}", app_path($path));
+            }
+
+            // Config stubs...
+            $config_stubs = [
+                'fortify.php',
+                'laravel-multilingual-routes.php',
+                'locales.php',
+            ];
+
+            foreach ($config_stubs as $config) {
+                copy(__DIR__ . "/../../stubs/config/{$config}", config_path($config));
+            }
         }
 
         // Add languages
@@ -157,109 +163,111 @@ class HearthCommand extends Command
             $this->maybeAddLocale();
         }
 
-        // Route stubs...
-        $route_stubs = [
-            'fortify.php',
-            'organizations.php',
-            'resources.php',
-            'web.php',
-        ];
+        if (! App::environment('testing')) {
+            // Route stubs...
+            $route_stubs = [
+                'fortify.php',
+                'organizations.php',
+                'resources.php',
+                'web.php',
+            ];
 
-        foreach ($route_stubs as $route) {
-            copy(__DIR__ . "/../../stubs/routes/{$route}", base_path("routes/{$route}"));
-        }
+            foreach ($route_stubs as $route) {
+                copy(__DIR__ . "/../../stubs/routes/{$route}", base_path("routes/{$route}"));
+            }
 
-        // Factories...
-        $factories = [
-            'InvitationFactory.php',
-            'OrganizationFactory.php',
-            'ResourceFactory.php',
-            'UserFactory.php',
-        ];
+            // Factories...
+            $factories = [
+                'InvitationFactory.php',
+                'OrganizationFactory.php',
+                'ResourceFactory.php',
+                'UserFactory.php',
+            ];
 
-        foreach ($factories as $factory) {
-            copy(__DIR__ . "/../../database/factories/{$factory}", base_path("database/factories/{$factory}"));
-        }
+            foreach ($factories as $factory) {
+                copy(__DIR__ . "/../../database/factories/{$factory}", base_path("database/factories/{$factory}"));
+            }
 
-        // Tests...
-        $test_stubs = [
-            'AccountDeletionTest.php',
-            'AuthenticationTest.php',
-            'EmailVerificationTest.php',
-            'LocalizationTest.php',
-            'OrganizationTest.php',
-            'PasswordChangeTest.php',
-            'PasswordConfirmationTest.php',
-            'PasswordResetTest.php',
-            'RegistrationTest.php',
-            'ResourceTest.php',
-            'TwoFactorAuthenticationTest.php',
-        ];
+            // Tests...
+            $test_stubs = [
+                'AccountDeletionTest.php',
+                'AuthenticationTest.php',
+                'EmailVerificationTest.php',
+                'LocalizationTest.php',
+                'OrganizationTest.php',
+                'PasswordChangeTest.php',
+                'PasswordConfirmationTest.php',
+                'PasswordResetTest.php',
+                'RegistrationTest.php',
+                'ResourceTest.php',
+                'TwoFactorAuthenticationTest.php',
+            ];
 
-        (new Filesystem())->delete(base_path('tests/Feature/ExampleTest.php'));
+            (new Filesystem())->delete(base_path('tests/Feature/ExampleTest.php'));
 
-        foreach ($test_stubs as $test) {
-            copy(__DIR__ . "/../../stubs/tests/{$test}", base_path("tests/Feature/{$test}"));
-        }
+            foreach ($test_stubs as $test) {
+                copy(__DIR__ . "/../../stubs/tests/{$test}", base_path("tests/Feature/{$test}"));
+            }
 
-        // Views...
-        (new Filesystem())->copyDirectory(__DIR__.'/../../stubs/resources/views/', resource_path('views'));
+            // Views...
+            (new Filesystem())->copyDirectory(__DIR__.'/../../stubs/resources/views/', resource_path('views'));
 
-        // View components...
-        $components = [
-            'AppLayout.php',
-            'GuestLayout.php',
-        ];
+            // View components...
+            $components = [
+                'AppLayout.php',
+                'GuestLayout.php',
+            ];
 
-        foreach ($components as $component) {
-            copy(__DIR__ . "/../../stubs/app/View/Components/{$component}", app_path("View/Components/{$component}"));
-        }
+            foreach ($components as $component) {
+                copy(__DIR__ . "/../../stubs/app/View/Components/{$component}", app_path("View/Components/{$component}"));
+            }
 
-        // Fonts...
-        $this->replaceInFile(
-            'https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;0,700;1,400;1,700',
-            'https://fonts.googleapis.com/css2?family=Comic+Neue:ital,wght@0,400;0,700;1,400;1,700&display=swap',
-            config_path('google-fonts.php')
-        );
-
-        // Mix configuration...
-        copy(__DIR__ . '/../../stubs/webpack.mix.js', base_path('webpack.mix.js'));
-
-        // Assets...
-        (new Filesystem())->delete(resource_path('css/app.css'));
-        (new Filesystem())->copyDirectory(__DIR__.'/../../stubs/resources/css/', resource_path('css'));
-        (new Filesystem())->copyDirectory(__DIR__.'/../../stubs/resources/js/', resource_path('js'));
-
-        // Language files...
-        (new Filesystem())->copyDirectory(__DIR__.'/../../stubs/resources/lang/', resource_path('lang'));
-
-        // Enable two-factor authentication
-        if ($this->option('two-factor')) {
+            // Fonts...
             $this->replaceInFile(
-                "// Features::twoFactorAuthentication([ 'confirmPassword' => true ]),",
-                "Features::twoFactorAuthentication([ 'confirmPassword' => true ]),",
-                config_path('fortify.php')
+                'https://fonts.googleapis.com/css2?family=Inter:ital,wght@0,400;0,700;1,400;1,700',
+                'https://fonts.googleapis.com/css2?family=Comic+Neue:ital,wght@0,400;0,700;1,400;1,700&display=swap',
+                config_path('google-fonts.php')
             );
-        }
 
-        if ($this->option('organizations')) {
-            $this->replaceInFile(
-                "'organizations' => [
+            // Mix configuration...
+            copy(__DIR__ . '/../../stubs/webpack.mix.js', base_path('webpack.mix.js'));
+
+            // Assets...
+            (new Filesystem())->delete(resource_path('css/app.css'));
+            (new Filesystem())->copyDirectory(__DIR__.'/../../stubs/resources/css/', resource_path('css'));
+            (new Filesystem())->copyDirectory(__DIR__.'/../../stubs/resources/js/', resource_path('js'));
+
+            // Language files...
+            (new Filesystem())->copyDirectory(__DIR__.'/../../stubs/resources/lang/', resource_path('lang'));
+
+            // Enable two-factor authentication
+            if ($this->option('two-factor')) {
+                $this->replaceInFile(
+                    "// Features::twoFactorAuthentication([ 'confirmPassword' => true ]),",
+                    "Features::twoFactorAuthentication([ 'confirmPassword' => true ]),",
+                    config_path('fortify.php')
+                );
+            }
+
+            if ($this->option('organizations')) {
+                $this->replaceInFile(
+                    "'organizations' => [
         'enabled' => false,",
-                "'organizations' => [
+                    "'organizations' => [
         'enabled' => true,",
-                config_path('hearth.php')
-            );
-        }
+                    config_path('hearth.php')
+                );
+            }
 
-        if ($this->option('resources')) {
-            $this->replaceInFile(
-                "'resources' => [
+            if ($this->option('resources')) {
+                $this->replaceInFile(
+                    "'resources' => [
         'enabled' => false,",
-                "'resources' => [
+                    "'resources' => [
         'enabled' => true,",
-                config_path('hearth.php')
-            );
+                    config_path('hearth.php')
+                );
+            }
         }
 
         $this->line('');
@@ -280,7 +288,7 @@ class HearthCommand extends Command
         if ($continue) {
             $languages = (new LanguageRepository())->getList();
 
-            $language = $this->anticipate('Choose a language', $languages);
+            $language = $this->anticipate('Choose a locale', $languages);
 
             if (in_array($language, array_keys($languages))) {
                 $language_code = $language;
@@ -291,12 +299,14 @@ class HearthCommand extends Command
             }
 
             if ($language_code) {
-                $this->replaceInFile(
-                    "'{$after}',",
-                    "'{$after}',
+                if (! App::environment('testing')) {
+                    $this->replaceInFile(
+                        "'{$after}',",
+                        "'{$after}',
         '{$language_code}',",
-                    config_path('locales.php')
-                );
+                        config_path('locales.php')
+                    );
+                }
 
                 $this->info("{$languages[$language_code]} added to locales!");
             } else {

--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -301,7 +301,7 @@ class HearthCommand extends Command
                 $this->info("{$languages[$language_code]} added to locales!");
             } else {
                 $language_code = $after;
-                $this->error('You selected an invalid locale. Please try again, or type "no" to proceed without adding more locales.');
+                $this->error('You entered an invalid locale code. Please try again, or type "no" to proceed without adding more locales.');
             }
 
             $this->maybeAddLocale($language_code);

--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -282,17 +282,23 @@ class HearthCommand extends Command
 
             $language = $this->anticipate('Choose a language', $languages);
 
-            $language_code = array_search($language, $languages);
+            if (in_array($language, array_keys($languages))) {
+                $language_code = $language;
+            } elseif ($language) {
+                $language_code = array_search($language, $languages);
+            } else {
+                $language_code = false;
+            }
 
             if ($language_code) {
                 $this->replaceInFile(
                     "'{$after}',",
                     "'{$after}',
-            '{$language_code}',",
+        '{$language_code}',",
                     config_path('locales.php')
                 );
 
-                $this->info("{$language} added to locales!");
+                $this->info("{$languages[$language_code]} added to locales!");
             } else {
                 $language_code = $after;
                 $this->error('You selected an invalid locale. Please try again, or type "no" to proceed without adding more locales.');

--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -273,25 +273,30 @@ class HearthCommand extends Command
      * @param  string  $after
      * @return void
      */
-    protected function maybeAddLocale($after = 'en')
+    protected function maybeAddLocale($after = 'fr')
     {
-        $continue = $this->choice('Do you want to add support for an additional locale?', ['yes', 'no']);
+        $continue = $this->confirm('Do you want to add support for an additional locale?', true);
 
-        if ($continue === 'yes') {
+        if ($continue) {
             $languages = (new LanguageRepository())->getList();
 
             $language = $this->anticipate('Choose a language', $languages);
 
             $language_code = array_search($language, $languages);
 
-            $this->replaceInFile(
-                "'{$after}',",
-                "'{$after}',
-        '{$language_code}',",
-                config_path('locales.php')
-            );
+            if ($language_code) {
+                $this->replaceInFile(
+                    "'{$after}',",
+                    "'{$after}',
+            '{$language_code}',",
+                    config_path('locales.php')
+                );
 
-            $this->info("{$language} added to locales!");
+                $this->info("{$language} added to locales!");
+            } else {
+                $language_code = $after;
+                $this->error('You selected an invalid locale. Please try again, or type "no" to proceed without adding more locales.');
+            }
 
             $this->maybeAddLocale($language_code);
         }

--- a/tests/ConsoleTest.php
+++ b/tests/ConsoleTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Hearth\Tests;
+
+class ConsoleTest extends TestCase
+{
+    public function test_install_command()
+    {
+        $this->artisan('hearth:install')
+            ->expectsConfirmation('Do you want to add support for an additional locale?', 'yes')
+            ->expectsQuestion('Choose a locale', 'Welsh')
+            ->expectsOutput('Welsh added to locales!')
+            ->expectsConfirmation('Do you want to add support for an additional locale?', 'no')
+            ->assertExitCode(0);
+    }
+}

--- a/tests/ConsoleTest.php
+++ b/tests/ConsoleTest.php
@@ -10,6 +10,15 @@ class ConsoleTest extends TestCase
             ->expectsConfirmation('Do you want to add support for an additional locale?', 'yes')
             ->expectsQuestion('Choose a locale', 'Welsh')
             ->expectsOutput('Welsh added to locales!')
+            ->expectsConfirmation('Do you want to add support for an additional locale?', 'yes')
+            ->expectsQuestion('Choose a locale', 'fa')
+            ->expectsOutput('Persian added to locales!')
+            ->expectsConfirmation('Do you want to add support for an additional locale?', 'yes')
+            ->expectsQuestion('Choose a locale', 'Dwarvish')
+            ->expectsOutput('You entered an invalid locale code. Please try again, or type "no" to proceed without adding more locales.')
+            ->expectsConfirmation('Do you want to add support for an additional locale?', 'yes')
+            ->expectsQuestion('Choose a locale', '')
+            ->expectsOutput('You entered an invalid locale code. Please try again, or type "no" to proceed without adding more locales.')
             ->expectsConfirmation('Do you want to add support for an additional locale?', 'no')
             ->assertExitCode(0);
     }


### PR DESCRIPTION
This PR changes the locale adding process as follows:

1. It's now a `confirm` which defaults to `yes` instead of `no`.
2. Any input will be checked to see if it's a valid locale code, as follows:
   - If a language name is entered from the autocomplete, e.g. 'Mexican Spanish', the appropriate code (`es-mx`) will be looked up and added to the array.
   - If the autocomplete is ignored and a user enters a locale code (e.g. `fa`), it will be validated against the list of locales and added if it's a valid locale code.
   - If any other input, including a blank string, is entered (e.g. if the user just presses <kbd>enter</kbd>), an error message will be displayed advising the user that the locale was not valid and that they can try again or type "no" to stop adding locales.

### Testing

1. [Install this branch](https://getcomposer.org/doc/05-repositories.md#loading-a-package-from-a-vcs-repository) as a Composer dependency in an empty Laravel project.
2. Run `php artisan hearth:install` or `sail artisan hearth:install`.
3. Try the various scenarios of locale input described above.