### PR TITLE
fix: prevent deletion of user if they are sole organization admin

### DIFF
--- a/stubs/app/Http/Requests/DestroyUserRequest.php
+++ b/stubs/app/Http/Requests/DestroyUserRequest.php
@@ -44,6 +44,19 @@ class DestroyUserRequest extends FormRequest
                     __('hearth::auth.wrong_password')
                 );
             }
+            if (count($this->user()->organizations) > 0) {
+                foreach ($this->user()->organizations as $organization) {
+                    if ($organization->administrators()->count() === 1 && $this->user()->isAdministratorOf($organization)) {
+                        $validator->errors()->add(
+                            'organizations',
+                            __(
+                                'organization.error_new_administrator_required_before_user_deletion',
+                                ['organization' => '<a href="' . localized_route('organizations.edit', $organization) . '">' . $organization->name . '</a>'],
+                            )
+                        );
+                    }
+                }
+            }
         })->validateWithBag('destroyAccount');
 
         return;

--- a/stubs/resources/lang/en/organization.php
+++ b/stubs/resources/lang/en/organization.php
@@ -28,4 +28,5 @@ return [
     'action_cancel_user_role_update' => 'Cancel',
     'action_remove_member' => 'Remove',
     'action_remove_member_with_name' => 'Remove :user from :organization',
+    'error_new_administrator_required_before_user_deletion' => 'You must assign a new administrator to your organization, :organization, before deleting your account.',
 ];

--- a/stubs/resources/views/partials/validation-errors.blade.php
+++ b/stubs/resources/views/partials/validation-errors.blade.php
@@ -4,7 +4,7 @@
             <p>{{ __('hearth::forms.errors_found_message') }}</p>
             <ul>
             @foreach ($bag->all() as $error)
-                <li>{{ $error }}</li>
+                <li>{!! $error !!}</li>
             @endforeach
             </ul>
         </x-hearth-alert>


### PR DESCRIPTION
Resolves #75.

Attempting to delete one's user account if one is the only administrator of an organization should fail with the error message:

> You must assign a new administrator to your organization, [Organization Name], before deleting your account.