### PR TITLE
feat: add individual hints to checkbox and radio groups (fix #90)

### DIFF
--- a/resources/views/components/checkboxes.blade.php
+++ b/resources/views/components/checkboxes.blade.php
@@ -1,6 +1,10 @@
-@foreach($options as $value => $label)
+@foreach($options as $value => $atts)
 <div class="field">
-    <input {!! $attributes !!} type="checkbox" name="{{ $name }}[]" id="{{ $name }}-{{ $value }}" value="{{ $value }}" {!! $describedBy() ? 'aria-describedby="' . $describedBy() . '"' : '' !!} @if (in_array($value, $selected, true)) checked @endif {!! $invalid ? 'aria-invalid="true"' : '' !!} />
-    <x-hearth-label for="{{ $name }}-{{ $value }}">{{ $label }}</x-hearth-label>
+    @php($hint = isset($atts['hint']) ? $name . '-' . $value . '-hint' : '')
+    <input {!! $attributes !!} type="checkbox" name="{{ $name }}[]" id="{{ $name }}-{{ $value }}" value="{{ $value }}" {!! $describedBy($hint) ? 'aria-describedby="' . $describedBy($hint) . '"' : '' !!} @if (in_array($value, $selected, true)) checked @endif {!! $invalid ? 'aria-invalid="true"' : '' !!} />
+    <x-hearth-label for="{{ $name }}-{{ $value }}">{{ $atts['label'] }}</x-hearth-label>
+    @if(isset($atts['hint']))
+    <x-hearth-hint for="{{ $name }}-{{ $value }}">{{ $atts['hint'] }}</x-hearth-hint>
+    @endif
 </div>
 @endforeach

--- a/resources/views/components/radio-buttons.blade.php
+++ b/resources/views/components/radio-buttons.blade.php
@@ -1,6 +1,10 @@
-@foreach($options as $value => $label)
+@foreach($options as $value => $atts)
 <div class="field">
-    <input {!! $attributes !!} type="radio" name="{{ $name }}" id="{{ $name }}-{{ $value }}" value="{{ $value }}" {!! $describedBy() ? 'aria-describedby="' . $describedBy() . '"' : '' !!} @if ($value === $selected) checked @endif {!! $invalid ? 'aria-invalid="true"' : '' !!} />
-    <x-hearth-label for="{{ $name }}-{{ $value }}">{{ $label }}</x-hearth-label>
+    @php($hint = isset($atts['hint']) ? $name . '-' . $value . '-hint' : '')
+    <input {!! $attributes !!} type="radio" name="{{ $name }}" id="{{ $name }}-{{ $value }}" value="{{ $value }}" {!! $describedBy($hint) ? 'aria-describedby="' . $describedBy($hint) . '"' : '' !!} @if ($value === $selected) checked @endif {!! $invalid ? 'aria-invalid="true"' : '' !!} />
+    <x-hearth-label for="{{ $name }}-{{ $value }}">{{ $atts['label'] }}</x-hearth-label>
+    @if(isset($atts['hint']))
+    <x-hearth-hint for="{{ $name }}-{{ $value }}">{{ $atts['hint'] }}</x-hearth-hint>
+    @endif
 </div>
 @endforeach

--- a/src/Components/Checkboxes.php
+++ b/src/Components/Checkboxes.php
@@ -29,7 +29,7 @@ class Checkboxes extends Component
     /**
      * The checkbox options.
      *
-     * @var array
+     * @var (string|array)[]
      */
     public array $options;
 
@@ -61,6 +61,13 @@ class Checkboxes extends Component
      */
     public function __construct($name, $options, $selected = [], $bag = 'default', $hinted = false)
     {
+        $options = array_map(function ($option) {
+            if (!is_array($option)) {
+                return ['label' => $option];
+            }
+            return $option;
+        }, $options);
+
         $this->name = $name;
         $this->options = $options;
         $this->selected = $selected;

--- a/src/Components/Checkboxes.php
+++ b/src/Components/Checkboxes.php
@@ -62,9 +62,10 @@ class Checkboxes extends Component
     public function __construct($name, $options, $selected = [], $bag = 'default', $hinted = false)
     {
         $options = array_map(function ($option) {
-            if (!is_array($option)) {
+            if (! is_array($option)) {
                 return ['label' => $option];
             }
+
             return $option;
         }, $options);
 

--- a/src/Components/RadioButtons.php
+++ b/src/Components/RadioButtons.php
@@ -62,9 +62,10 @@ class RadioButtons extends Component
     public function __construct($name, $options, $selected = null, $bag = 'default', $hinted = false)
     {
         $options = array_map(function ($option) {
-            if (!is_array($option)) {
+            if (! is_array($option)) {
                 return ['label' => $option];
             }
+
             return $option;
         }, $options);
 

--- a/src/Components/RadioButtons.php
+++ b/src/Components/RadioButtons.php
@@ -29,7 +29,7 @@ class RadioButtons extends Component
     /**
      * The radio button options.
      *
-     * @var array
+     * @var (string|array)[]
      */
     public $options;
 
@@ -61,6 +61,13 @@ class RadioButtons extends Component
      */
     public function __construct($name, $options, $selected = null, $bag = 'default', $hinted = false)
     {
+        $options = array_map(function ($option) {
+            if (!is_array($option)) {
+                return ['label' => $option];
+            }
+            return $option;
+        }, $options);
+
         $this->name = $name;
         $this->options = $options;
         $this->selected = $selected;

--- a/src/Traits/AriaDescribable.php
+++ b/src/Traits/AriaDescribable.php
@@ -7,11 +7,12 @@ trait AriaDescribable
     /**
      * Generate the aria-describedby attribute for the form input.
      *
+     * @param string $hint
      * @return string
      */
-    public function describedBy()
+    public function describedBy($hint = '')
     {
-        $descriptors = [];
+        $descriptors = [$hint];
 
         if ($this->hinted) {
             $descriptors[] = ($this->hinted === true) ? $this->name . '-hint' : $this->hinted;
@@ -21,6 +22,6 @@ trait AriaDescribable
             $descriptors[] = str_replace(['[', ']'], ['_', ''], $this->name) . '-error';
         }
 
-        return implode(' ', $descriptors);
+        return implode(' ', array_filter($descriptors));
     }
 }

--- a/tests/Components/CheckboxesTest.php
+++ b/tests/Components/CheckboxesTest.php
@@ -61,6 +61,31 @@ class CheckboxesTest extends TestCase
         $view->assertSee('aria-describedby="favourite-flavour-hint"', false);
     }
 
+    public function test_checkboxes_reference_individual_hinst()
+    {
+        $view = $this->withViewErrors([])
+            ->component(
+                Checkboxes::class,
+                [
+                    'name' => 'flavour',
+                    'options' => [
+                        'vanilla' => [
+                            'label' => 'Vanilla',
+                            'hint' => 'Rich and delicate.',
+                        ],
+                        'chocolate' => [
+                            'label' => 'Chocolate',
+                            'hint' => 'Decadent and delicious.',
+                        ],
+                    ],
+                    'hinted' => 'favourite-flavour-hint',
+                ],
+            );
+
+        $view->assertSee('aria-describedby="flavour-chocolate-hint favourite-flavour-hint"', false);
+        $view->assertSee('aria-describedby="flavour-vanilla-hint favourite-flavour-hint"', false);
+    }
+
     public function test_checkboxes_component_includes_attribute()
     {
         $view = $this->withViewErrors([])

--- a/tests/Components/CheckboxesTest.php
+++ b/tests/Components/CheckboxesTest.php
@@ -61,7 +61,7 @@ class CheckboxesTest extends TestCase
         $view->assertSee('aria-describedby="favourite-flavour-hint"', false);
     }
 
-    public function test_checkboxes_reference_individual_hinst()
+    public function test_checkboxes_reference_individual_hints()
     {
         $view = $this->withViewErrors([])
             ->component(

--- a/tests/Components/RadioButtonsTest.php
+++ b/tests/Components/RadioButtonsTest.php
@@ -61,7 +61,7 @@ class RadioButtonsTest extends TestCase
         $view->assertSee('aria-describedby="favourite-flavour-hint"', false);
     }
 
-    public function test_radio_buttons_reference_individual_hinst()
+    public function test_radio_buttons_reference_individual_hints()
     {
         $view = $this->withViewErrors([])
             ->component(

--- a/tests/Components/RadioButtonsTest.php
+++ b/tests/Components/RadioButtonsTest.php
@@ -61,6 +61,31 @@ class RadioButtonsTest extends TestCase
         $view->assertSee('aria-describedby="favourite-flavour-hint"', false);
     }
 
+    public function test_radio_buttons_reference_individual_hinst()
+    {
+        $view = $this->withViewErrors([])
+            ->component(
+                RadioButtons::class,
+                [
+                    'name' => 'flavour',
+                    'options' => [
+                        'vanilla' => [
+                            'label' => 'Vanilla',
+                            'hint' => 'Rich and delicate.',
+                        ],
+                        'chocolate' => [
+                            'label' => 'Chocolate',
+                            'hint' => 'Decadent and delicious.',
+                        ],
+                    ],
+                    'hinted' => 'favourite-flavour-hint',
+                ],
+            );
+
+        $view->assertSee('aria-describedby="flavour-chocolate-hint favourite-flavour-hint"', false);
+        $view->assertSee('aria-describedby="flavour-vanilla-hint favourite-flavour-hint"', false);
+    }
+
     public function test_radio_buttons_component_includes_attribute()
     {
         $view = $this->withViewErrors([])


### PR DESCRIPTION
This PR modifies the `$options` parameter for the `Checkboxes` and `RadioButtons` components to accept an array of `string`s which will be used as the checkboxes' or radio buttons' labels, or an associative array with values for `label` and `hint` respectively.