### PR TITLE
fix: resolve issue with improperly selected options in select component

### DIFF
--- a/resources/views/components/select.blade.php
+++ b/resources/views/components/select.blade.php
@@ -10,6 +10,6 @@
     {!! $invalid ? 'aria-invalid="true"' : '' !!}
 >
     @foreach($options as $option => $label)
-    <option value="{{ $option }}" @selected($selected)>{{ $label }}</option>
+    <option value="{{ $option }}" @selected($selected == $option)>{{ $label }}</option>
     @endforeach
 </select>

--- a/tests/Components/SelectTest.php
+++ b/tests/Components/SelectTest.php
@@ -39,7 +39,7 @@ class SelectTest extends TestCase
                 ],
             );
 
-            $view->assertSee('<option value="chocolate" selected', false);
-            $view->assertDontSee('<option value="vanilla" selected', false);
+        $view->assertSee('<option value="chocolate" selected', false);
+        $view->assertDontSee('<option value="vanilla" selected', false);
     }
 }

--- a/tests/Components/SelectTest.php
+++ b/tests/Components/SelectTest.php
@@ -39,6 +39,7 @@ class SelectTest extends TestCase
                 ],
             );
 
-        $view->assertSee('<option value="chocolate" selected', false);
+            $view->assertSee('<option value="chocolate" selected', false);
+            $view->assertDontSee('<option value="vanilla" selected', false);
     }
 }


### PR DESCRIPTION
Hearth v2 included a regression in the Select component. Laravel 9's new [`@selected`](https://laravel.com/docs/9.x/blade#checked-and-selected) directive expects a true/false value, and was being passed a string. This updates the component to compare the option and selected values in the directive and adds a test to validate that only the selected option receives the selected attribute.