### PR TITLE
fix: resolve issue with button type not being overridden (fix #121)

### DIFF
--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -1,3 +1,2 @@
-<button {{ $attributes->merge(['type' => 'submit']) }}>
-    {{ $slot }}
-</button>
+<button {{ $attributes->merge(['type' => $type]) }}>{{ $slot }}</button>
+

--- a/resources/views/components/button.blade.php
+++ b/resources/views/components/button.blade.php
@@ -1,2 +1,2 @@
-<button {{ $attributes->merge(['type' => $type]) }}>{{ $slot }}</button>
+<button {{ $attributes->merge(['type' => 'submit']) }}>{{ $slot }}</button>
 

--- a/src/Components/Button.php
+++ b/src/Components/Button.php
@@ -8,20 +8,12 @@ use Illuminate\View\View;
 class Button extends Component
 {
     /**
-     * The button type.
-     *
-     * @var string
-     */
-    public $type;
-
-    /**
      * Create a new component instance.
      *
      * @return void
      */
-    public function __construct($type = 'submit')
+    public function __construct()
     {
-        $this->type = $type;
     }
 
     /**

--- a/src/Components/Button.php
+++ b/src/Components/Button.php
@@ -19,7 +19,7 @@ class Button extends Component
      *
      * @return void
      */
-    public function __construct($type = "submit")
+    public function __construct($type = 'submit')
     {
         $this->type = $type;
     }

--- a/tests/Components/ButtonTest.php
+++ b/tests/Components/ButtonTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Hearth\Tests\Components;
+
+use Hearth\Tests\TestCase;
+
+class ButtonTest extends TestCase
+{
+    public function test_button_component_renders()
+    {
+        $view = $this->blade(
+            '<x-hearth-button>Button</x-hearth-button>'
+        );
+
+        $view->assertSee('<button type="submit">Button</button>', false);
+    }
+
+    public function test_button_component_renders_with_different_type()
+    {
+        $view = $this->blade(
+            '<x-hearth-button type="button">Button</x-hearth-button>'
+        );
+
+        $view->assertSee('<button type="button">Button</button>', false);
+    }
+
+    public function test_button_component_renders_with_class()
+    {
+        $view = $this->blade(
+            '<x-hearth-button class="secondary">Button</x-hearth-button>'
+        );
+
+        $view->assertSee('<button type="submit" class="secondary">Button</button>', false);
+    }
+}


### PR DESCRIPTION
Fixes button type override. Default type is `submit`.

### Testing

- Verify that button type can be overridden.
- Verify that `class` and `name` attributes can be passed to button.