### PR TITLE
feat!: make Organization model translatable

### DIFF
--- a/database/migrations/create_organizations_table.php.stub
+++ b/database/migrations/create_organizations_table.php.stub
@@ -15,8 +15,7 @@ class CreateOrganizationsTable extends Migration
     {
         Schema::create('organizations', function (Blueprint $table) {
             $table->id();
-            $table->string('name');
-            $table->string('slug');
+            $table->json('name');
             $table->string('locality');
             $table->string('region');
             $table->timestamps();

--- a/stubs/app/Http/Requests/DestroyUserRequest.php
+++ b/stubs/app/Http/Requests/DestroyUserRequest.php
@@ -51,7 +51,7 @@ class DestroyUserRequest extends FormRequest
                             'organizations',
                             __(
                                 'organization.error_new_administrator_required_before_user_deletion',
-                                ['organization' => '<a href="' . localized_route('organizations.edit', $organization) . '">' . $organization->name . '</a>'],
+                                ['organization' => '<a href="' . localized_route('organizations.edit', $organization) . '">' . $organization->getTranslation('name', locale()) . '</a>'],
                             )
                         );
                     }

--- a/stubs/app/Models/Organization.php
+++ b/stubs/app/Models/Organization.php
@@ -8,14 +8,13 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Notifications\Notifiable;
 use ShiftOneLabs\LaravelCascadeDeletes\CascadesDeletes;
-use Spatie\Sluggable\HasSlug;
-use Spatie\Sluggable\SlugOptions;
+use Spatie\Translatable\HasTranslations;
 
 class Organization extends Model
 {
     use CascadesDeletes;
     use HasFactory;
-    use HasSlug;
+    use HasTranslations;
     use Notifiable;
 
     /**
@@ -39,34 +38,13 @@ class Organization extends Model
     ];
 
     /**
-     * Get the options for generating the slug.
-     */
-    public function getSlugOptions(): SlugOptions
-    {
-        return SlugOptions::create()
-            ->generateSlugsFrom('name')
-            ->saveSlugsTo('slug');
-    }
-
-    /**
-     * Get the route key for the model.
+     * The attributes that are translatable.
      *
-     * @return string
+     * @var array<string>
      */
-    public function getRouteKeyName()
-    {
-        return 'slug';
-    }
-
-    /**
-     * Get the route placeholder for the model.
-     *
-     * @return string
-     */
-    public function getRouteKeyPlaceholder()
-    {
-        return 'organization';
-    }
+    public $translatable = [
+        'name',
+    ];
 
     /**
      * Get the route prefix for the model.

--- a/stubs/tests/AuthenticationTest.php
+++ b/stubs/tests/AuthenticationTest.php
@@ -14,7 +14,7 @@ class AuthenticationTest extends TestCase
     {
         $response = $this->get(localized_route('login'));
 
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 
     public function test_users_can_authenticate_using_the_login_screen()
@@ -52,7 +52,7 @@ class AuthenticationTest extends TestCase
         ]);
 
         $response = $this->get(localized_route('users.edit'));
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 
     public function test_guests_can_not_edit_profiles()

--- a/stubs/tests/EmailVerificationTest.php
+++ b/stubs/tests/EmailVerificationTest.php
@@ -21,7 +21,7 @@ class EmailVerificationTest extends TestCase
 
         $response = $this->actingAs($user)->get(localized_route('verification.notice'));
 
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 
     public function test_email_can_be_verified()

--- a/stubs/tests/OrganizationTest.php
+++ b/stubs/tests/OrganizationTest.php
@@ -32,7 +32,9 @@ class OrganizationTest extends TestCase
             'region' => 'NS',
         ]);
 
-        $url = localized_route('organizations.show', ['organization' => Str::slug($user->name . ' Consulting')]);
+        $organization = Organization::where('name->en', $user->name . ' Consulting')->first();
+
+        $url = localized_route('organizations.show', $organization);
 
         $response->assertSessionHasNoErrors();
 

--- a/stubs/tests/OrganizationTest.php
+++ b/stubs/tests/OrganizationTest.php
@@ -24,7 +24,7 @@ class OrganizationTest extends TestCase
         $user = User::factory()->create();
 
         $response = $this->actingAs($user)->get(localized_route('organizations.create'));
-        $response->assertStatus(200);
+        $response->assertOk();
 
         $response = $this->actingAs($user)->post(localized_route('organizations.create'), [
             'name' => $user->name . ' Consulting',
@@ -53,7 +53,7 @@ class OrganizationTest extends TestCase
             ->create();
 
         $response = $this->actingAs($user)->get(localized_route('organizations.edit', $organization));
-        $response->assertStatus(200);
+        $response->assertOk();
 
         $response = $this->actingAs($user)->put(localized_route('organizations.update', $organization), [
             'name' => $organization->name,
@@ -75,14 +75,14 @@ class OrganizationTest extends TestCase
             ->create();
 
         $response = $this->actingAs($user)->get(localized_route('organizations.edit', $organization));
-        $response->assertStatus(403);
+        $response->assertForbidden();
 
         $response = $this->actingAs($user)->put(localized_route('organizations.update', $organization), [
             'name' => $organization->name,
             'locality' => 'St John\'s',
             'region' => 'NL',
         ]);
-        $response->assertStatus(403);
+        $response->assertForbidden();
     }
 
     public function test_non_members_can_not_edit_organizations()
@@ -103,14 +103,14 @@ class OrganizationTest extends TestCase
             ->create();
 
         $response = $this->actingAs($user)->get(localized_route('organizations.edit', $other_organization));
-        $response->assertStatus(403);
+        $response->assertForbidden();
 
         $response = $this->actingAs($user)->put(localized_route('organizations.update', $other_organization), [
             'name' => $other_organization->name,
             'locality' => 'St John\'s',
             'region' => 'NL',
         ]);
-        $response->assertStatus(403);
+        $response->assertForbidden();
     }
 
     public function test_organizations_can_be_translated()
@@ -191,7 +191,7 @@ class OrganizationTest extends TestCase
                 'role' => 'admin',
             ]);
 
-        $response->assertStatus(403);
+        $response->assertForbidden();
     }
 
     public function test_only_administrator_can_not_downgrade_their_role()
@@ -271,7 +271,7 @@ class OrganizationTest extends TestCase
                 'role' => 'member',
             ]);
 
-        $response->assertStatus(403);
+        $response->assertForbidden();
     }
 
     public function test_users_with_admin_role_can_cancel_invitations()
@@ -320,7 +320,7 @@ class OrganizationTest extends TestCase
             ->from(localized_route('organizations.edit', ['organization' => $organization]))
             ->delete(route('invitations.destroy', ['invitation' => $invitation]));
 
-        $response->assertStatus(403);
+        $response->assertForbidden();
     }
 
     public function test_existing_members_cannot_be_invited()
@@ -451,7 +451,7 @@ class OrganizationTest extends TestCase
             ->from(localized_route('organizations.edit', ['organization' => $organization]))
             ->delete(route('memberships.destroy', $membership));
 
-        $response->assertStatus(403);
+        $response->assertForbidden();
     }
 
     public function test_only_administrator_can_not_remove_themself()
@@ -547,7 +547,7 @@ class OrganizationTest extends TestCase
             'current_password' => 'password',
         ]);
 
-        $response->assertStatus(403);
+        $response->assertForbidden();
     }
 
     public function test_non_members_can_not_delete_organizations()
@@ -576,7 +576,7 @@ class OrganizationTest extends TestCase
             'current_password' => 'password',
         ]);
 
-        $response->assertStatus(403);
+        $response->assertForbidden();
     }
 
     public function test_users_can_view_organizations()
@@ -594,10 +594,10 @@ class OrganizationTest extends TestCase
         ]);
 
         $response = $this->get(localized_route('organizations.index'));
-        $response->assertStatus(200);
+        $response->assertOk();
 
         $response = $this->get(localized_route('organizations.show', $organization));
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 
     public function test_guests_can_not_view_organizations()

--- a/stubs/tests/OrganizationTest.php
+++ b/stubs/tests/OrganizationTest.php
@@ -2,15 +2,14 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
-use App\Models\User;
 use App\Models\Invitation;
 use App\Models\Membership;
-use Illuminate\Support\Str;
 use App\Models\Organization;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\URL;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class OrganizationTest extends TestCase
 {

--- a/stubs/tests/PasswordConfirmationTest.php
+++ b/stubs/tests/PasswordConfirmationTest.php
@@ -16,7 +16,7 @@ class PasswordConfirmationTest extends TestCase
 
         $response = $this->actingAs($user)->get(localized_route('password.confirm'));
 
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 
     public function test_password_can_be_confirmed()

--- a/stubs/tests/PasswordResetTest.php
+++ b/stubs/tests/PasswordResetTest.php
@@ -16,7 +16,7 @@ class PasswordResetTest extends TestCase
     {
         $response = $this->get(localized_route('password.request'));
 
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 
     public function test_reset_password_link_can_be_requested()
@@ -41,7 +41,7 @@ class PasswordResetTest extends TestCase
         Notification::assertSentTo($user, ResetPassword::class, function ($notification) {
             $response = $this->get(route('password.reset', $notification->token));
 
-            $response->assertStatus(200);
+            $response->assertOk();
 
             return true;
         });

--- a/stubs/tests/RegistrationTest.php
+++ b/stubs/tests/RegistrationTest.php
@@ -13,7 +13,7 @@ class RegistrationTest extends TestCase
     {
         $response = $this->get(localized_route('register'));
 
-        $response->assertStatus(200);
+        $response->assertOk();
     }
 
     public function test_new_users_can_register()

--- a/stubs/tests/ResourceTest.php
+++ b/stubs/tests/ResourceTest.php
@@ -21,7 +21,7 @@ class ResourceTest extends TestCase
         $user = User::factory()->create();
 
         $response = $this->actingAs($user)->get(localized_route('resources.create'));
-        $response->assertStatus(200);
+        $response->assertOk();
 
         $response = $this->actingAs($user)->post(localized_route('resources.create'), [
             'user_id' => $user->id,
@@ -48,7 +48,7 @@ class ResourceTest extends TestCase
         $resource = Resource::factory()->create(['user_id' => $user->id]);
 
         $response = $this->actingAs($user)->get(localized_route('resources.edit', $resource));
-        $response->assertStatus(200);
+        $response->assertOk();
 
         $response = $this->actingAs($user)->put(localized_route('resources.update', $resource), [
             'title' => $resource->title,
@@ -94,13 +94,13 @@ class ResourceTest extends TestCase
         $resource = Resource::factory()->create();
 
         $response = $this->actingAs($user)->get(localized_route('resources.edit', $resource));
-        $response->assertStatus(403);
+        $response->assertForbidden();
 
         $response = $this->actingAs($user)->put(localized_route('resources.update', $resource), [
             'title' => $resource->title,
             'summary' => 'This is my updated resource.',
         ]);
-        $response->assertStatus(403);
+        $response->assertForbidden();
     }
 
     public function test_users_can_delete_resources_belonging_to_them()
@@ -149,6 +149,6 @@ class ResourceTest extends TestCase
             'current_password' => 'password',
         ]);
 
-        $response->assertStatus(403);
+        $response->assertForbidden();
     }
 }

--- a/stubs/tests/ResourceTest.php
+++ b/stubs/tests/ResourceTest.php
@@ -57,7 +57,7 @@ class ResourceTest extends TestCase
         $response->assertRedirect(localized_route('resources.show', $resource));
     }
 
-    public function test_users_can_translate_resources_belonging_to_them()
+    public function test_resources_can_be_translated()
     {
         if (! config('hearth.resources.enabled')) {
             return $this->markTestSkipped('Resource support is not enabled.');


### PR DESCRIPTION
This is a followup to #128, which makes the Organization name column translatable and removes the Organization slug column.

This PR also changes test stubs to use `assertOk` and `assertForbidden` instead of asserting status codes.