### PR TITLE
test: remove user creation for testing translation of Resource model

### DIFF
--- a/stubs/tests/ResourceTest.php
+++ b/stubs/tests/ResourceTest.php
@@ -63,8 +63,7 @@ class ResourceTest extends TestCase
             return $this->markTestSkipped('Resource support is not enabled.');
         }
 
-        $user = User::factory()->create();
-        $resource = Resource::factory()->create(['user_id' => $user->id]);
+        $resource = Resource::factory()->create();
 
         $resource->setTranslation('title', 'en', 'title in English');
         $resource->setTranslation('title', 'fr', 'title in French');


### PR DESCRIPTION
Remove user creation from a test case "test_resources_can_be_translated", as we don't need explicit user creation for the test.