### PR TITLE
fix: don't use strict comparison for radio buttons

### DIFF
--- a/resources/views/components/radio-buttons.blade.php
+++ b/resources/views/components/radio-buttons.blade.php
@@ -1,7 +1,7 @@
 @foreach($options as $value => $atts)
 <div class="field">
     @php($hint = isset($atts['hint']) ? $name . '-' . $value . '-hint' : '')
-    <input {!! $attributes !!} type="radio" name="{{ $name }}" id="{{ $name }}-{{ $value }}" value="{{ $value }}" {!! $describedBy($hint) ? 'aria-describedby="' . $describedBy($hint) . '"' : '' !!} @checked($checked === $value) {!! $invalid ? 'aria-invalid="true"' : '' !!} />
+    <input {!! $attributes !!} type="radio" name="{{ $name }}" id="{{ $name }}-{{ $value }}" value="{{ $value }}" {!! $describedBy($hint) ? 'aria-describedby="' . $describedBy($hint) . '"' : '' !!} @checked($checked == $value) {!! $invalid ? 'aria-invalid="true"' : '' !!} />
     <x-hearth-label for="{{ $name }}-{{ $value }}">{{ $atts['label'] }}</x-hearth-label>
     @if(isset($atts['hint']))
     <x-hearth-hint for="{{ $name }}-{{ $value }}">{{ $atts['hint'] }}</x-hearth-hint>

--- a/src/Components/RadioButtons.php
+++ b/src/Components/RadioButtons.php
@@ -36,7 +36,7 @@ class RadioButtons extends Component
     /**
      * The checked option.
      *
-     * @var null|string
+     * @var null|string|int
      */
     public $checked;
 

--- a/tests/Components/RadioButtonsTest.php
+++ b/tests/Components/RadioButtonsTest.php
@@ -120,4 +120,23 @@ class RadioButtonsTest extends TestCase
         $view->assertSee('value="vanilla"  checked', false);
         $view->assertDontSee('value="chocolate"  checked', false);
     }
+
+    public function test_radio_buttons_component_includes_checked_boolean_button()
+    {
+        $view = $this->withViewErrors([])
+            ->blade(
+                '<x-hearth-radio-buttons :name="$name" :options="$options" :checked="$checked" />',
+                [
+                    'name' => 'email_me',
+                    'options' => [
+                        '1' => 'Yes',
+                        '0' => 'No',
+                    ],
+                    'checked' => 1
+                ],
+            );
+
+        $view->assertSee('value="1"  checked', false);
+        $view->assertDontSee('value="0"  checked', false);
+    }
 }

--- a/tests/Components/RadioButtonsTest.php
+++ b/tests/Components/RadioButtonsTest.php
@@ -132,7 +132,7 @@ class RadioButtonsTest extends TestCase
                         '1' => 'Yes',
                         '0' => 'No',
                     ],
-                    'checked' => 1
+                    'checked' => 1,
                 ],
             );
 


### PR DESCRIPTION
Using a strict (identical) comparison, `===`, within the `@checked` direction means that a radio button would never be checked if its `value` was "1" (a string) but the model property was 1 (an integer). Using a looser (equals) comparison, `==`, resolves the issue.