### PR TITLE
feat: add Vite support (resolves #158)

### DIFF
--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -48,6 +48,11 @@ class HearthCommand extends Command
                 ] + $packages;
             }, false);
 
+            $this->updateNodePackages(function ($packages) {
+                return [
+                    'sass' => '^1.53',
+                ] + $packages;
+            });
             $this->flushNodeModules();
 
             // Name...

--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -309,7 +309,7 @@ class HearthCommand extends Command
 
         ksort($packages[$configurationKey]);
 
-        $packages['scripts']['postinstall'] = 'npm run dev';
+        $packages['scripts']['postinstall'] = 'npm run build';
 
         ksort($packages['scripts']);
 

--- a/src/Commands/HearthCommand.php
+++ b/src/Commands/HearthCommand.php
@@ -48,13 +48,6 @@ class HearthCommand extends Command
                 ] + $packages;
             }, false);
 
-            $this->updateNodePackages(function ($packages) {
-                return [
-                    'resolve-url-loader' => '^4.0.0',
-                    'sass' => '^1.35',
-                    'sass-loader' => '^12.1',
-                ] + $packages;
-            });
             $this->flushNodeModules();
 
             // Name...
@@ -159,8 +152,8 @@ class HearthCommand extends Command
                 copy($stub, str_replace(__DIR__.'/../../stubs/tests', base_path('tests'), $stub));
             }
 
-            // Mix configuration...
-            copy(__DIR__.'/../../stubs/webpack.mix.js', base_path('webpack.mix.js'));
+            // Vite configuration...
+            copy(__DIR__.'/../../stubs/vite.config.js', base_path('vite.config.js'));
 
             // Larastan/PHPStan configuration
             copy(__DIR__.'/../../stubs/phpstan.neon.dist', base_path('phpstan.neon.dist'));

--- a/stubs/resources/js/app.js
+++ b/stubs/resources/js/app.js
@@ -1,4 +1,4 @@
-require("./bootstrap");
+import "./bootstrap";
 
 import Alpine from 'alpinejs'
 

--- a/stubs/resources/js/bootstrap.js
+++ b/stubs/resources/js/bootstrap.js
@@ -4,6 +4,7 @@
  * CSRF token as a header based on the value of the "XSRF" token cookie.
  */
 
- window.axios = require("axios");
+ import axios from "axios";
+ window.axios = axios;
 
  window.axios.defaults.headers.common["X-Requested-With"] = "XMLHttpRequest";

--- a/stubs/resources/views/partials/head.blade.php
+++ b/stubs/resources/views/partials/head.blade.php
@@ -16,11 +16,10 @@
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
 <!-- Styles -->
-<link href="{{ mix('css/app.css') }}" rel="stylesheet" />
+@vite('resources/css/app.css')
 @googlefonts
 
 <!-- Scripts -->
 <script>document.documentElement.className = document.documentElement.className.replace("no-js", "js");</script>
-<script src="{{ mix('js/manifest.js') }}" defer></script>
-<script src="{{ mix('js/vendor.js') }}" defer></script>
-<script src="{{ mix('js/app.js') }}" defer></script>
+@vite('resources/js/app.js')
+

--- a/stubs/resources/views/partials/head.blade.php
+++ b/stubs/resources/views/partials/head.blade.php
@@ -16,7 +16,7 @@
 <link rel="apple-touch-icon" href="/apple-touch-icon.png">
 
 <!-- Styles -->
-@vite('resources/css/app.css')
+@vite('resources/css/app.scss')
 @googlefonts
 
 <!-- Scripts -->

--- a/stubs/vite.config.js
+++ b/stubs/vite.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vite';
+import laravel from 'laravel-vite-plugin';
+
+export default defineConfig({
+    plugins: [
+        laravel([
+            'resources/css/app.scss',
+            'resources/js/app.js',
+        ]),
+    ],
+});

--- a/stubs/webpack.mix.js
+++ b/stubs/webpack.mix.js
@@ -1,9 +1,0 @@
-const mix = require("laravel-mix");
-
-mix.js("resources/js/app.js", "public/js").extract();
-
-mix.sass("resources/css/app.scss", "public/css/app.css");
-
-if (mix.inProduction()) {
-    mix.version();
-}


### PR DESCRIPTION
Laravel Vite uses `npm run dev` the same way that Laravel Mix used `npm run watch-poll`. This was causing integration tests to time out. Resolves #154.