### PR TITLE
feat: add standalone RadioButton component (resolves #145)

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,7 +7,8 @@ parameters:
         - resources
         - src
     level: 5 # The level 9 is the highest level
-    ignoreErrors: []
+    ignoreErrors:
+        - '#Call to an undefined static method Illuminate\\Support\\Facades\\Route::multilingual\(\)#'
     excludePaths: []
     checkMissingIterableValueType: false
     scanFiles:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,8 +7,7 @@ parameters:
         - resources
         - src
     level: 5 # The level 9 is the highest level
-    ignoreErrors:
-        - '#Call to an undefined static method Illuminate\\Support\\Facades\\Route::multilingual\(\)#'
+    ignoreErrors: []
     excludePaths: []
     checkMissingIterableValueType: false
     scanFiles:

--- a/resources/views/components/radio-button.blade.php
+++ b/resources/views/components/radio-button.blade.php
@@ -1,0 +1,12 @@
+<input type="radio"
+    {!! $attributes->merge([
+        'name' => $name,
+        'id' => $id,
+        'value' => $value,
+    ]) !!}
+    {{ $autofocus ? 'autofocus' : '' }}
+    @disabled($disabled)
+    @checked($checked)
+    {!! $describedBy() ? 'aria-describedby="' . $describedBy() . '"' : '' !!}
+    {!! $invalid ? 'aria-invalid="true"' : '' !!}
+>

--- a/src/Components/RadioButton.php
+++ b/src/Components/RadioButton.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Hearth\Components;
+
+use Hearth\Traits\AriaDescribable;
+use Hearth\Traits\HandlesValidation;
+use Illuminate\View\Component;
+use Illuminate\View\View;
+
+class RadioButton extends Component
+{
+    use AriaDescribable;
+    use HandlesValidation;
+
+    /**
+     * The name of the form input.
+     *
+     * @var null|string
+     */
+    public $name;
+
+    /**
+     * The value of the form input.
+     *
+     * @var null|string
+     */
+    public $value;
+
+    /**
+     * The id of the form input.
+     *
+     * @var null|string
+     */
+    public $id;
+
+    /**
+     * The error bag associated with the form input.
+     *
+     * @var null|string
+     */
+    public $bag;
+
+    /**
+     * Whether the checkbox is checked.
+     *
+     * @var bool
+     */
+    public bool $checked;
+
+    /**
+     * Whether the form input has validation errors.
+     *
+     * @var bool
+     */
+    public $invalid;
+
+    /**
+     * Whether the form input has a hint associated with it, or the id of the hint.
+     *
+     * @var bool|string
+     */
+    public $hinted;
+
+    /**
+     * Whether the form input is disabled.
+     *
+     * @var bool
+     */
+    public $disabled;
+
+    /**
+     * Whether the form input is should be autofocused.
+     *
+     * @var bool
+     */
+    public $autofocus;
+
+    /**
+     * Create a new component instance.
+     *
+     * @return void
+     */
+    public function __construct(
+        $name,
+        $value,
+        $id = null,
+        $bag = 'default',
+        $checked = false,
+        $hinted = false,
+        $disabled = false,
+        $autofocus = false
+    ) {
+        $this->name = $name;
+        $this->value = $value;
+        $this->id = $id ?? $this->name.'-'.$this->value;
+        $this->bag = $bag;
+        $this->checked = $checked;
+        $this->hinted = $hinted;
+        $this->invalid = $this->hasErrors($this->name, $this->bag);
+        $this->disabled = $disabled;
+        $this->autofocus = $autofocus;
+    }
+
+    /**
+     * Get the view / contents that represent the component.
+     */
+    public function render(): View
+    {
+        return view('hearth::components.radio-button');
+    }
+}

--- a/src/Components/RadioButton.php
+++ b/src/Components/RadioButton.php
@@ -92,7 +92,7 @@ class RadioButton extends Component
     ) {
         $this->name = $name;
         $this->value = $value;
-        $this->id = $id ?? $this->name.'-'.$this->value;
+        $this->id = $id ?? $this->name.'-'.Str::slug($value);
         $this->bag = $bag;
         $this->checked = $checked;
         $this->hinted = $hinted;

--- a/src/Components/RadioButton.php
+++ b/src/Components/RadioButton.php
@@ -4,6 +4,7 @@ namespace Hearth\Components;
 
 use Hearth\Traits\AriaDescribable;
 use Hearth\Traits\HandlesValidation;
+use Illuminate\Support\Str;
 use Illuminate\View\Component;
 use Illuminate\View\View;
 

--- a/src/HearthServiceProvider.php
+++ b/src/HearthServiceProvider.php
@@ -15,6 +15,7 @@ use Hearth\Components\Label;
 use Hearth\Components\LanguageSwitcher;
 use Hearth\Components\LocaleSelect;
 use Hearth\Components\PasswordConfirmation;
+use Hearth\Components\RadioButton;
 use Hearth\Components\RadioButtons;
 use Hearth\Components\Select;
 use Hearth\Components\Textarea;
@@ -51,6 +52,7 @@ class HearthServiceProvider extends PackageServiceProvider
             ->hasViewComponent('hearth', LanguageSwitcher::class)
             ->hasViewComponent('hearth', LocaleSelect::class)
             ->hasViewComponent('hearth', PasswordConfirmation::class)
+            ->hasViewComponent('hearth', RadioButton::class)
             ->hasViewComponent('hearth', RadioButtons::class)
             ->hasViewComponent('hearth', Select::class)
             ->hasViewComponent('hearth', Textarea::class)

--- a/stubs/app/Http/Controllers/OrganizationController.php
+++ b/stubs/app/Http/Controllers/OrganizationController.php
@@ -113,7 +113,7 @@ class OrganizationController extends Controller
     {
         $organization->requestsToJoin()->save($request->user());
 
-        flash(__('You have successfully requested to join :organization. You will be notified when an administrator has approved or denied your request.', ['organization' => $organization->name]), 'success');
+        flash(__('You have successfully requested to join :organization. You will be notified when an administrator has approved or denied your request.', ['organization' => $organization->getTranslation('name', locale())]), 'success');
 
         return redirect(\localized_route('organizations.show', $organization));
     }

--- a/stubs/phpstan.neon.dist
+++ b/stubs/phpstan.neon.dist
@@ -16,5 +16,6 @@ parameters:
     # The level 9 is the highest level
     level: 5
 
-    ignoreErrors: []
+    ignoreErrors:
+        - '#Call to an undefined static method Illuminate\\Support\\Facades\\Route::multilingual\(\)#'
     checkMissingIterableValueType: false

--- a/tests/Components/RadioButtonTest.php
+++ b/tests/Components/RadioButtonTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Hearth\Tests\Components;
+
+use Hearth\Components\RadioButton;
+use Hearth\Tests\TestCase;
+
+class RadioButtonTest extends TestCase
+{
+    public function test_radio_button_component_renders()
+    {
+        $view = $this->withViewErrors([])
+            ->component(
+                RadioButton::class,
+                [
+                    'name' => 'flavour',
+                    'value' => 'vanilla',
+                ],
+            );
+
+        $view->assertSee('id="flavour-vanilla"', false);
+    }
+
+    public function test_radio_button_component_references_hint()
+    {
+        $view = $this->withViewErrors([])
+            ->component(
+                RadioButton::class,
+                [
+                    'name' => 'flavour',
+                    'value' => 'vanilla',
+                    'hinted' => true,
+                ],
+            );
+
+        $view->assertSee('aria-describedby="flavour-hint"', false);
+    }
+
+    public function test_radio_button_component_references_custom_hint()
+    {
+        $view = $this->withViewErrors([])
+            ->component(
+                RadioButton::class,
+                [
+                    'name' => 'flavour',
+                    'value' => 'vanilla',
+                    'hinted' => 'flavour-vanilla-hint',
+                ],
+            );
+
+        $view->assertSee('aria-describedby="flavour-vanilla-hint"', false);
+    }
+
+    public function test_radio_button_component_includes_attribute()
+    {
+        $view = $this->withViewErrors([])
+            ->blade(
+                '<x-hearth-radio-button :name="$name" :value="$value" x-model="flavour" />',
+                [
+                    'name' => 'flavour',
+                    'value' => 'vanilla',
+                ],
+            );
+
+        $view->assertSee('x-model="flavour"', false);
+    }
+
+    public function test_radio_button_component_can_be_checked()
+    {
+        $view = $this->withViewErrors([])
+            ->blade(
+                '<x-hearth-radio-button :name="$name" :value="$value" :checked="true" />',
+                [
+                    'name' => 'flavour',
+                    'value' => 'vanilla',
+                ],
+            );
+
+        $view->assertSee('checked', false);
+    }
+}


### PR DESCRIPTION
See #145. This can be used for a custom radio group where additional content (e.g. a conditional field between two successive radio buttons) is needed.