### PR TITLE
fix: handle keyed validation errors (resolves #149)

### DIFF
--- a/src/Traits/HandlesValidation.php
+++ b/src/Traits/HandlesValidation.php
@@ -3,6 +3,7 @@
 namespace Hearth\Traits;
 
 use Illuminate\Support\Facades\View;
+use Illuminate\Support\Str;
 use Illuminate\Support\ViewErrorBag;
 
 trait HandlesValidation
@@ -22,6 +23,12 @@ trait HandlesValidation
 
         $name = str_replace(['[', ']'], ['.', ''], $name);
 
-        return $errors->getBag($bag)->has($name);
+        foreach($errors->getBag($bag)->keys() as $key) {
+            if (Str::startsWith($key, $name)) {
+               return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Traits/HandlesValidation.php
+++ b/src/Traits/HandlesValidation.php
@@ -23,9 +23,9 @@ trait HandlesValidation
 
         $name = str_replace(['[', ']'], ['.', ''], $name);
 
-        foreach($errors->getBag($bag)->keys() as $key) {
+        foreach ($errors->getBag($bag)->keys() as $key) {
             if (Str::startsWith($key, $name)) {
-               return true;
+                return true;
             }
         }
 

--- a/tests/Components/CheckboxesTest.php
+++ b/tests/Components/CheckboxesTest.php
@@ -138,4 +138,21 @@ class CheckboxesTest extends TestCase
 
         $view->assertSee('id="flavour-french-vanilla"', false);
     }
+
+    public function test_checkboxes_component_handles_validation()
+    {
+        $view = $this->withViewErrors(['flavour.0.required' => 'Vanilla is a required flavour.'])
+            ->blade(
+                '<x-hearth-checkboxes :name="$name" :options="$options" />',
+                [
+                    'name' => 'flavour',
+                    'options' => [
+                        'French vanilla' => 'Vanilla',
+                        'chocolate' => 'Chocolate',
+                    ],
+                ],
+            );
+
+        $view->assertSee('aria-invalid', false);
+    }
 }


### PR DESCRIPTION
Resolves #149. This approaches uses the `MessageBag` class’ `keys()` method to perform a substring comparison against the error keys.