### PR TITLE
fix: normalize ids to more standard characters

### DIFF
--- a/resources/views/components/checkboxes.blade.php
+++ b/resources/views/components/checkboxes.blade.php
@@ -1,6 +1,6 @@
 @foreach($options as $option)
 <div class="field">
-    @php($id = $name . '-' . Str::slug($option['value']))
+    @php($id = Str::slug($name) . '-' . Str::slug($option['value']))
     @php($hint = isset($option['hint']) ? $id . '-hint' : '')
     <input {!! $attributes !!} type="checkbox" name="{{ $name }}[]" id="{{ $id }}" value="{{ $option['value'] }}" {!! $describedBy($hint) ? 'aria-describedby="' . $describedBy($hint) . '"' : '' !!} @checked(in_array($option['value'], $checked)) {!! $invalid ? 'aria-invalid="true"' : '' !!} />
     <x-hearth-label for="{{ $id }}">{{ $option['label'] }}</x-hearth-label>

--- a/resources/views/components/checkboxes.blade.php
+++ b/resources/views/components/checkboxes.blade.php
@@ -1,6 +1,6 @@
 @foreach($options as $option)
 <div class="field">
-    @php($id = Str::slug($name) . '-' . Str::slug($option['value']))
+    @php($id = Str::slug("{$name}-{$option['value']}"))
     @php($hint = isset($option['hint']) ? $id . '-hint' : '')
     <input {!! $attributes !!} type="checkbox" name="{{ $name }}[]" id="{{ $id }}" value="{{ $option['value'] }}" {!! $describedBy($hint) ? 'aria-describedby="' . $describedBy($hint) . '"' : '' !!} @checked(in_array($option['value'], $checked)) {!! $invalid ? 'aria-invalid="true"' : '' !!} />
     <x-hearth-label for="{{ $id }}">{{ $option['label'] }}</x-hearth-label>

--- a/resources/views/components/radio-buttons.blade.php
+++ b/resources/views/components/radio-buttons.blade.php
@@ -1,6 +1,6 @@
 @foreach($options as $option)
 <div class="field">
-    @php($id = Str::slug($name) . '-' . Str::slug($option['value']))
+    @php($id = Str::slug("{$name}-{$option['value']}"))
     @php($hint = isset($option['hint']) ? $id . '-hint' : '')
     <input {!! $attributes !!} type="radio" name="{{ $name }}" id="{{ $id }}" value="{{ $option['value'] }}" {!! $describedBy($hint) ? 'aria-describedby="' . $describedBy($hint) . '"' : '' !!} @checked($checked == $option['value']) {!! $invalid ? 'aria-invalid="true"' : '' !!} />
     <x-hearth-label for="{{ $id }}">{{ $option['label'] }}</x-hearth-label>

--- a/resources/views/components/radio-buttons.blade.php
+++ b/resources/views/components/radio-buttons.blade.php
@@ -1,6 +1,6 @@
 @foreach($options as $option)
 <div class="field">
-    @php($id = $name . '-' . Str::slug($option['value']))
+    @php($id = Str::slug($name) . '-' . Str::slug($option['value']))
     @php($hint = isset($option['hint']) ? $id . '-hint' : '')
     <input {!! $attributes !!} type="radio" name="{{ $name }}" id="{{ $id }}" value="{{ $option['value'] }}" {!! $describedBy($hint) ? 'aria-describedby="' . $describedBy($hint) . '"' : '' !!} @checked($checked == $option['value']) {!! $invalid ? 'aria-invalid="true"' : '' !!} />
     <x-hearth-label for="{{ $id }}">{{ $option['label'] }}</x-hearth-label>

--- a/tests/Components/CheckboxesTest.php
+++ b/tests/Components/CheckboxesTest.php
@@ -175,6 +175,26 @@ class CheckboxesTest extends TestCase
             );
 
         $view->assertSee('id="flavour-french-vanilla"', false);
+
+        $view = $this->withViewErrors([])
+            ->blade(
+                '<x-hearth-checkboxes :name="$name" :options="$options" />',
+                [
+                    'name' => 'courses[dessert][ice-cream][flavour]',
+                    'options' => [
+                        [
+                            'value' => 'French vanilla',
+                            'label' => 'Vanilla',
+                        ],
+                        [
+                            'value' => 'chocolate',
+                            'label' => 'Chocolate',
+                        ],
+                    ],
+                ],
+            );
+
+        $view->assertSee('id="coursesdessertice-creamflavour-french-vanilla"', false);
     }
 
     public function test_checkboxes_component_handles_validation()

--- a/tests/Components/RadioButtonsTest.php
+++ b/tests/Components/RadioButtonsTest.php
@@ -199,5 +199,25 @@ class RadioButtonsTest extends TestCase
             );
 
         $view->assertSee('id="flavour-french-vanilla"', false);
+
+        $view = $this->withViewErrors([])
+            ->blade(
+                '<x-hearth-radio-buttons :name="$name" :options="$options" />',
+                [
+                    'name' => 'courses[dessert][ice-cream][flavour]',
+                    'options' => [
+                        [
+                            'value' => 'French vanilla',
+                            'label' => 'Vanilla',
+                        ],
+                        [
+                            'value' => 'chocolate',
+                            'label' => 'Chocolate',
+                        ],
+                    ],
+                ],
+            );
+
+        $view->assertSee('id="coursesdessertice-creamflavour-french-vanilla"', false);
     }
 }


### PR DESCRIPTION
As discussed earlier, this PR passes checkbox and radio button field `name` attributes through a slug filter when generating their ID so as to avoid the presence of square brackets in circumstances where the checkboxes or radio buttons reference array values.